### PR TITLE
Fix AsyncProfiler compilation errors

### DIFF
--- a/core/src/main/java/one/profiler/AsyncProfiler.java
+++ b/core/src/main/java/one/profiler/AsyncProfiler.java
@@ -19,8 +19,6 @@ import java.io.InputStream;
 public class AsyncProfiler implements AsyncProfilerMXBean {
     private static AsyncProfiler instance;
 
-    baiduhello
-
     private AsyncProfiler() {
     }
 

--- a/core/src/main/java/one/profiler/AsyncProfilerMXBean.java
+++ b/core/src/main/java/one/profiler/AsyncProfilerMXBean.java
@@ -29,5 +29,4 @@ public interface AsyncProfilerMXBean {
     String dumpCollapsed(Counter counter);
     String dumpTraces(int maxTraces);
     String dumpFlat(int maxMethods);
-    void hello()
 }


### PR DESCRIPTION
## Summary
- remove the stray `baiduhello` token from `AsyncProfiler`
- delete the unused `hello` method from `AsyncProfilerMXBean`

## Testing
- mvn -pl core -am -DskipTests compile *(fails: network is unreachable when resolving oss-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cadabee7588329a072f81386695ce6